### PR TITLE
URDF Files for Red and Blue C1T Trucks

### DIFF
--- a/urdf/blue_truck.urdf
+++ b/urdf/blue_truck.urdf
@@ -2,7 +2,7 @@
   <link name="base_link" />
   <link name="footprint" />
   <link name="imu" />
-  <link name="lidar" />
+  <link name="laser" />
 
 
   <joint name="imu_joint" type="fixed">
@@ -11,9 +11,9 @@
     <origin xyz="0.295 0 0.021" rpy="0 0 0" />
   </joint>
 
-  <joint name="lidar_joint" type="fixed">
+  <joint name="laser_joint" type="fixed">
     <parent link="base_link"/>
-    <child link="lidar"/>
+    <child link="laser"/>
     <origin xyz="0.447675 0.0 0.143" rpy="0 0 3.141593" />
   </joint>
 

--- a/urdf/blue_truck.urdf
+++ b/urdf/blue_truck.urdf
@@ -1,0 +1,26 @@
+<robot name="red_truck">
+  <link name="base_link" />
+  <link name="footprint" />
+  <link name="imu" />
+  <link name="lidar" />
+
+
+  <joint name="imu_joint" type="fixed">
+    <parent link="base_link"/>
+    <child link="imu"/>
+    <origin xyz="0.295 0 0.021" rpy="0 0 0" />
+  </joint>
+
+  <joint name="lidar_joint" type="fixed">
+    <parent link="base_link"/>
+    <child link="lidar"/>
+    <origin xyz="0.447675 0.0 0.143" rpy="0 0 3.141592" />
+  </joint>
+
+  <joint name="footprint_joint" type="fixed">
+    <parent link="base_link"/>
+    <child link="footprint"/>
+    <origin xyz="0 0 -0.043" />
+  </joint>
+
+</robot>

--- a/urdf/blue_truck.urdf
+++ b/urdf/blue_truck.urdf
@@ -14,7 +14,7 @@
   <joint name="lidar_joint" type="fixed">
     <parent link="base_link"/>
     <child link="lidar"/>
-    <origin xyz="0.447675 0.0 0.143" rpy="0 0 3.141592" />
+    <origin xyz="0.447675 0.0 0.143" rpy="0 0 3.141593" />
   </joint>
 
   <joint name="footprint_joint" type="fixed">

--- a/urdf/red_truck.urdf
+++ b/urdf/red_truck.urdf
@@ -14,7 +14,7 @@
   <joint name="laser_joint" type="fixed">
     <parent link="base_link"/>
     <child link="laser"/>
-    <origin xyz="0.41 -0.01 0.185" rpy="0 0 3.141592" />
+    <origin xyz="0.41 -0.01 0.185" rpy="0 0 3.141593" />
   </joint>
 
   <joint name="footprint_joint" type="fixed">

--- a/urdf/red_truck.urdf
+++ b/urdf/red_truck.urdf
@@ -2,7 +2,7 @@
   <link name="base_link" />
   <link name="footprint" />
   <link name="imu" />
-  <link name="lidar" />
+  <link name="laser" />
 
 
   <joint name="imu_joint" type="fixed">
@@ -11,10 +11,10 @@
     <origin xyz="0.226 0.047 0.071" rpy="0 0 0" />
   </joint>
 
-  <joint name="lidar_joint" type="fixed">
+  <joint name="laser_joint" type="fixed">
     <parent link="base_link"/>
-    <child link="lidar"/>
-    <origin xyz="0.409 0.0 0.185" rpy="0 0 3.141592" />
+    <child link="laser"/>
+    <origin xyz="0.41 -0.01 0.185" rpy="0 0 3.141592" />
   </joint>
 
   <joint name="footprint_joint" type="fixed">

--- a/urdf/red_truck.urdf
+++ b/urdf/red_truck.urdf
@@ -1,0 +1,26 @@
+<robot name="red_truck">
+  <link name="base_link" />
+  <link name="footprint" />
+  <link name="imu" />
+  <link name="lidar" />
+
+
+  <joint name="imu_joint" type="fixed">
+    <parent link="base_link"/>
+    <child link="imu"/>
+    <origin xyz="0.226 0.047 0.071" rpy="0 0 0" />
+  </joint>
+
+  <joint name="lidar_joint" type="fixed">
+    <parent link="base_link"/>
+    <child link="lidar"/>
+    <origin xyz="0.409 0.0 0.185" rpy="0 0 3.141592" />
+  </joint>
+
+  <joint name="footprint_joint" type="fixed">
+    <parent link="base_link"/>
+    <child link="footprint"/>
+    <origin xyz="0 0 -0.043" />
+  </joint>
+
+</robot>


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

This PR contains URDF files for the red and blue C1T trucks with links from the vehicles base link to the floor print, LiDAR, and IMU.

## Related GitHub Issue

## Related Jira Key
[CF-691](https://usdot-carma.atlassian.net/browse/CF-691)
[CF-815](https://usdot-carma.atlassian.net/browse/CF-815)

## Motivation and Context

The URDF contains measurements between the vehicle's sensors and base_link to allow for messages from both sensors to be transformed to the same coordinate frame.

## How Has This Been Tested?

`ros2 run robot_state_publisher robot_state_publisher <path to URDF>` displays the URDF in rviz with the appropriate translations and rotations applied to each link.

## Types of changes

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


[CF-815]: https://usdot-carma.atlassian.net/browse/CF-815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CF-691]: https://usdot-carma.atlassian.net/browse/CF-691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ