### PR TITLE
Add VESC parameters and update launch files

### DIFF
--- a/launch/drivers_launch.xml
+++ b/launch/drivers_launch.xml
@@ -1,7 +1,15 @@
 <launch>
-  <include file="$(find-pkg-share vesc_ackermann)/launch/ackermann_to_vesc_node.launch.xml"/>
-  <include file="$(find-pkg-share vesc_ackermann)/launch/vesc_to_odom_node.launch.xml"/>
-  <include file="$(find-pkg-share vesc_driver)/launch/vesc_driver_node.launch.py"/>
+  <node pkg="vesc_ackermann" exec="vesc_to_odom_node" name="vesc_to_odom_node">
+    <param from="$(find-pkg-share c1t_bringup)/params/params.yaml"/>
+  </node>
+
+  <node pkg="vesc_ackermann" exec="ackermann_to_vesc_node" name="ackermann_to_vesc_node">
+    <param from="$(find-pkg-share c1t_bringup)/params/params.yaml"/>
+  </node>
+
+  <node pkg="vesc_driver" exec="vesc_driver_node" name="vesc_driver_node">
+    <param from="$(find-pkg-share c1t_bringup)/params/params.yaml"/>
+  </node>
 
   <node pkg="twist_to_ackermann" exec="twist_to_ackermann_node" name="twist_to_ackermann_node">
     <remap from="/ackermann" to="/ackermann_cmd"/>

--- a/params/params.yaml
+++ b/params/params.yaml
@@ -171,3 +171,38 @@ scan_to_scan_filter_chain:
       type: laser_filters/LaserScanFootprintFilter
       params:
         inscribed_radius: 1.0
+
+vesc_to_odom_node:
+  ros__parameters:
+    odom_frame: odom
+    base_frame: base_link
+    speed_to_erpm_gain: 7317.8
+    speed_to_erpm_offset: 0.0
+    use_servo_cmd_to_calc_angular_velocity: True
+    steering_angle_to_servo_gain: 0.9135
+    steering_angle_to_servo_offset: 0.425
+    wheelbase: 0.3175
+    publish_tf: True
+
+ackermann_to_vesc_node:
+  ros__parameters:
+    speed_to_erpm_gain: 7317.8
+    speed_to_erpm_offset: 0.0
+    steering_angle_to_servo_gain: -0.9135
+    steering_angle_to_servo_offset: 0.425
+
+vesc_driver_node:
+  ros__parameters:
+    port: "/dev/ttyACM0"
+    brake_max: 200000.0
+    brake_min: -20000.0
+    current_max: 100.0
+    current_min: 0.0
+    duty_cycle_max: 0.0
+    duty_cycle_min: 0.0
+    position_max: 0.0
+    position_min: 0.0
+    servo_max: 0.85
+    servo_min: 0.15
+    speed_max: 23250.0
+    speed_min: -23250.0


### PR DESCRIPTION
# PR Details
## Description

This PR adds the VESC parameters to the `params.yaml` instead of relying on the hard-coded values in our fork of the `vesc` repository.

The VESC parameters were hard-coded into the related nodes' launch files from another repo. These parameters now live with other robot specific parameters.

## Related GitHub Issue

## Related Jira Key

Closes [CF-831](https://usdot-carma.atlassian.net/browse/CF-831)

## Motivation and Context

This is easier to maintain and is more readable for users.

## How Has This Been Tested?

Manually on one of the C1T trucks.

## Types of changes

- [x] New feature (non-breaking change that adds functionality)

## Checklist:

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[CF-831]: https://usdot-carma.atlassian.net/browse/CF-831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ