### PR TITLE
Add initial Route Server integration

### DIFF
--- a/behavior_trees/navigate_through_route_to_pose.xml
+++ b/behavior_trees/navigate_through_route_to_pose.xml
@@ -1,0 +1,8 @@
+<root main_tree_to_execute="MainTree">
+  <BehaviorTree ID="MainTree">
+    <PipelineSequence name="NavigateThroughRouteToPose">
+      <ComputeRoute goal="{goal}" path="{path}" error_code_id="{compute_route_error_code}"/>
+      <FollowPath path="{path}" controller_id="FollowPath" error_code_id="{follow_path_error_code}"/>
+    </PipelineSequence>
+  </BehaviorTree>
+</root>

--- a/graphs/chub.geojson
+++ b/graphs/chub.geojson
@@ -1,0 +1,22 @@
+{
+    "type": "FeatureCollection",
+    "name": "graph",
+    "crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:EPSG::3857" } },
+    "features": [
+    { "type": "Feature", "properties": { "id": 1 }, "geometry": { "type": "Point", "coordinates": [ 0.0, 0.0 ] } },
+    { "type": "Feature", "properties": { "id": 2 }, "geometry": { "type": "Point", "coordinates": [ 1.0, 0.0 ] } },
+    { "type": "Feature", "properties": { "id": 3 }, "geometry": { "type": "Point", "coordinates": [ 2.0, 0.0 ] } },
+    { "type": "Feature", "properties": { "id": 4 }, "geometry": { "type": "Point", "coordinates": [ 3.0, 0.0 ] } },
+    { "type": "Feature", "properties": { "id": 5 }, "geometry": { "type": "Point", "coordinates": [ 4.0, 0.0 ] } },
+    { "type": "Feature", "properties": { "id": 6 }, "geometry": { "type": "Point", "coordinates": [ 4.0, 1.0 ] } },
+    { "type": "Feature", "properties": { "id": 7 }, "geometry": { "type": "Point", "coordinates": [ 4.0, 2.0 ] } },
+    { "type": "Feature", "properties": { "id": 8 }, "geometry": { "type": "Point", "coordinates": [ 4.0, 3.0 ] } },
+    { "type": "Feature", "properties": { "id": 9, "startid": 1, "endid": 2 }, "geometry": { "type": "MultiLineString", "coordinates": [ [ [ 0.0, 0.0 ], [ 1.0, 0.0 ] ] ] } },
+    { "type": "Feature", "properties": { "id": 10, "startid": 2, "endid": 3 }, "geometry": { "type": "MultiLineString", "coordinates": [ [ [ 1.0, 0.0 ], [ 2.0, 0.0 ] ] ] } },
+    { "type": "Feature", "properties": { "id": 11, "startid": 3, "endid": 4 }, "geometry": { "type": "MultiLineString", "coordinates": [ [ [ 2.0, 0.0 ], [ 3.0, 0.0 ] ] ] } },
+    { "type": "Feature", "properties": { "id": 12, "startid": 4, "endid": 5 }, "geometry": { "type": "MultiLineString", "coordinates": [ [ [ 3.0, 0.0 ], [ 4.0, 0.0 ] ] ] } },
+    { "type": "Feature", "properties": { "id": 13, "startid": 5, "endid": 6 }, "geometry": { "type": "MultiLineString", "coordinates": [ [ [ 4.0, 0.0 ], [ 4.0, 1.0 ] ] ] } },
+    { "type": "Feature", "properties": { "id": 14, "startid": 6, "endid": 7 }, "geometry": { "type": "MultiLineString", "coordinates": [ [ [ 4.0, 1.0 ], [ 4.0, 2.0 ] ] ] } },
+    { "type": "Feature", "properties": { "id": 15, "startid": 7, "endid": 8 }, "geometry": { "type": "MultiLineString", "coordinates": [ [ [ 4.0, 2.0 ], [ 4.0, 3.0 ] ] ] } }
+    ]
+}

--- a/params/params.yaml
+++ b/params/params.yaml
@@ -9,6 +9,7 @@ bt_navigator:
     robot_base_frame: base_link
     odom_topic: odom
     navigators: ["navigate_to_pose"]
+    # default_nav_to_pose_bt_xml: "/home/ubuntu/c1t_ws/src/c1t_bringup/behavior_trees/navigate_through_route_to_pose.xml"
 
     navigate_to_pose:
       plugin: "nav2_bt_navigator/NavigateToPoseNavigator"


### PR DESCRIPTION
# PR Details
## Description

This PR adds the initial Route Server integration from a robot level. It adds a new Behavior Tree specification for the Nav2 BT Navigator, and it adds an example route graph for CHub.

## Related GitHub Issue

## Related Jira Key

Closes [CF-834](https://usdot-carma.atlassian.net/browse/CF-834)

## Motivation and Context

We need route following capabilities for port drayage.

## How Has This Been Tested?

Rudimentary testing in the TB 3 simulation environment.

## Types of changes

- [x] New feature (non-breaking change that adds functionality)

## Checklist:

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[CF-834]: https://usdot-carma.atlassian.net/browse/CF-834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ