### PR TITLE
Cf 878 automatic bagging

### DIFF
--- a/launch/c1t_bringup_launch.xml
+++ b/launch/c1t_bringup_launch.xml
@@ -4,6 +4,7 @@
   <include file="$(find-pkg-share c1t_bringup)/launch/navigation_launch.xml"/>
   <include file="$(find-pkg-share c1t_bringup)/launch/teleop_launch.xml"/>
   <include file="$(find-pkg-share c1t_bringup)/launch/transforms_launch.xml"/>
+  <include file="$(find-pkg-share c1t_bringup)/launch/ros2_rosbag.launch.py"/>
 
   <node pkg="foxglove_bridge" exec="foxglove_bridge" name="foxglove_bridge" args="--ros-args --log-level WARN"/>
 </launch>

--- a/launch/c1t_bringup_launch.xml
+++ b/launch/c1t_bringup_launch.xml
@@ -6,8 +6,7 @@
   <include file="$(find-pkg-share c1t_bringup)/launch/navigation_launch.xml"/>
   <include file="$(find-pkg-share c1t_bringup)/launch/teleop_launch.xml"/>
   <include file="$(find-pkg-share c1t_bringup)/launch/transforms_launch.xml"/>
-  <include file="$(find-pkg-share c1t_bringup)/launch/ros2_rosbag.launch.py">
-    <arg name="record_bag" value="$(var record_bag)"/>
-  </include>
+  <include file="$(find-pkg-share c1t_bringup)/launch/ros2_rosbag.launch.py" if="$(var record_bag)"/>
+
   <node pkg="foxglove_bridge" exec="foxglove_bridge" name="foxglove_bridge" args="--ros-args --log-level WARN"/>
 </launch>

--- a/launch/c1t_bringup_launch.xml
+++ b/launch/c1t_bringup_launch.xml
@@ -1,10 +1,13 @@
 <launch>
+  <arg name="record_bag" default="false"/>
+
   <include file="$(find-pkg-share c1t_bringup)/launch/drivers_launch.xml"/>
   <include file="$(find-pkg-share c1t_bringup)/launch/localization_launch.xml"/>
   <include file="$(find-pkg-share c1t_bringup)/launch/navigation_launch.xml"/>
   <include file="$(find-pkg-share c1t_bringup)/launch/teleop_launch.xml"/>
   <include file="$(find-pkg-share c1t_bringup)/launch/transforms_launch.xml"/>
-  <include file="$(find-pkg-share c1t_bringup)/launch/ros2_rosbag.launch.py"/>
-
+  <include file="$(find-pkg-share c1t_bringup)/launch/ros2_rosbag.launch.py">
+    <arg name="record_bag" value="$(var record_bag)"/>
+  </include>
   <node pkg="foxglove_bridge" exec="foxglove_bridge" name="foxglove_bridge" args="--ros-args --log-level WARN"/>
 </launch>

--- a/launch/ros2_rosbag.launch.py
+++ b/launch/ros2_rosbag.launch.py
@@ -29,34 +29,24 @@ import getpass
 # topics as provided in the appropriate configuration file.
 
 bag_dir = ''
-record_bag = "false"
 
 def record_ros2_rosbag(context: LaunchContext):
-    global bag_dir, record_bag
-    record_bag = LaunchConfiguration("record_bag").perform(context)
-    if record_bag == "true":
-        bag_dir = '/home/' + getpass.getuser() + '/bags/rosbag2_' + str(datetime.now().strftime('%Y-%m-%d_%H%M%S'))
-        proc = ExecuteProcess(
-            cmd=['ros2', 'bag', 'record', '-o', bag_dir, '-a'],
-            output='screen',
-            shell='true'
-            )
-        return [proc]
-    else:
-        return []
+    global bag_dir
+    bag_dir = '/home/' + getpass.getuser() + '/bags/rosbag2_' + str(datetime.now().strftime('%Y-%m-%d_%H%M%S'))
+    proc = ExecuteProcess(
+        cmd=['ros2', 'bag', 'record', '-o', bag_dir, '-a'],
+        output='screen',
+        shell='true'
+        )
+    return [proc]
 
 
 def on_shutdown(event, context):
-    if record_bag == "true":
-        params_file = os.path.join(get_package_share_directory("c1t_bringup"), "params", "params.yaml")
-        shutil.copy(params_file, bag_dir)
+    params_file = os.path.join(get_package_share_directory("c1t_bringup"), "params", "params.yaml")
+    shutil.copy(params_file, bag_dir)
 
 def generate_launch_description():
-    record_bag_arg = DeclareLaunchArgument(
-        "record_bag", default_value=TextSubstitution(text="false")
-    )
     return LaunchDescription([
-        record_bag_arg,
         OpaqueFunction(function=record_ros2_rosbag),
         RegisterEventHandler(
             OnShutdown(on_shutdown=on_shutdown)

--- a/launch/ros2_rosbag.launch.py
+++ b/launch/ros2_rosbag.launch.py
@@ -1,0 +1,57 @@
+# Copyright (C) 2023 LEIDOS.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from launch import LaunchDescription, LaunchContext
+from launch_ros.actions import Node
+from launch.actions import OpaqueFunction
+from launch.substitutions import LaunchConfiguration
+from ament_index_python.packages import get_package_share_directory
+from launch.actions import DeclareLaunchArgument, ExecuteProcess, RegisterEventHandler
+from launch.event_handlers import OnShutdown
+from launch.substitutions import PathJoinSubstitution
+from launch_ros.substitutions import FindPackageShare
+
+from datetime import datetime
+import pathlib
+import os
+import shutil
+
+# This function is used to generate a command to record a ROS 2 rosbag that excludes topics
+# topics as provided in the appropriate configuration file.
+
+bag_dir = ''
+
+def record_ros2_rosbag(context: LaunchContext):
+    global bag_dir
+        bag_dir = '/home/ubuntu/bags/rosbag2_' + str(datetime.now().strftime('%Y-%m-%d_%H%M%S'))
+        proc = ExecuteProcess(
+            cmd=['ros2', 'bag', 'record', '-o', bag_dir, '-a'],
+            output='screen',
+            shell='true'
+            )
+
+        return [proc]
+
+
+def on_shutdown(event, context):
+    params_file = os.path.join(get_package_share_directory("c1t_bringup"), "params", "params.yaml")
+    shutil.copy(params_file, bag_dir)
+
+def generate_launch_description():
+    return LaunchDescription([
+        OpaqueFunction(function=record_ros2_rosbag),
+        RegisterEventHandler(
+            OnShutdown(on_shutdown=on_shutdown)
+        )
+    ])

--- a/launch/ros2_rosbag.launch.py
+++ b/launch/ros2_rosbag.launch.py
@@ -15,15 +15,11 @@
 from launch import LaunchDescription, LaunchContext
 from launch.actions import OpaqueFunction
 from ament_index_python.packages import get_package_share_directory
-from launch.actions import DeclareLaunchArgument, ExecuteProcess, RegisterEventHandler
+from launch.actions import ExecuteProcess, RegisterEventHandler
 from launch.event_handlers import OnShutdown
-from launch.substitutions import TextSubstitution
 from datetime import datetime
-from launch.substitutions import LaunchConfiguration
-
 import os
 import shutil
-import getpass
 
 # This function is used to generate a command to record a ROS 2 rosbag that excludes topics
 # topics as provided in the appropriate configuration file.
@@ -32,11 +28,10 @@ bag_dir = ''
 
 def record_ros2_rosbag(context: LaunchContext):
     global bag_dir
-    bag_dir = '/home/' + getpass.getuser() + '/bags/rosbag2_' + str(datetime.now().strftime('%Y-%m-%d_%H%M%S'))
+    bag_dir = '/home/' + os.getlogin() + '/c1t_bags/rosbag2_' + str(datetime.now().strftime('%Y-%m-%d_%H%M%S'))
     proc = ExecuteProcess(
         cmd=['ros2', 'bag', 'record', '-o', bag_dir, '-a'],
         output='screen',
-        shell='true'
         )
     return [proc]
 

--- a/launch/ros2_rosbag.launch.py
+++ b/launch/ros2_rosbag.launch.py
@@ -13,43 +13,50 @@
 # limitations under the License.
 
 from launch import LaunchDescription, LaunchContext
-from launch_ros.actions import Node
 from launch.actions import OpaqueFunction
-from launch.substitutions import LaunchConfiguration
 from ament_index_python.packages import get_package_share_directory
 from launch.actions import DeclareLaunchArgument, ExecuteProcess, RegisterEventHandler
 from launch.event_handlers import OnShutdown
-from launch.substitutions import PathJoinSubstitution
-from launch_ros.substitutions import FindPackageShare
-
+from launch.substitutions import TextSubstitution
 from datetime import datetime
-import pathlib
+from launch.substitutions import LaunchConfiguration
+
 import os
 import shutil
+import getpass
 
 # This function is used to generate a command to record a ROS 2 rosbag that excludes topics
 # topics as provided in the appropriate configuration file.
 
 bag_dir = ''
+record_bag = "false"
 
 def record_ros2_rosbag(context: LaunchContext):
-    global bag_dir
-        bag_dir = '/home/ubuntu/bags/rosbag2_' + str(datetime.now().strftime('%Y-%m-%d_%H%M%S'))
+    global bag_dir, record_bag
+    record_bag = LaunchConfiguration("record_bag").perform(context)
+    if record_bag == "true":
+        bag_dir = '/home/' + getpass.getuser() + '/bags/rosbag2_' + str(datetime.now().strftime('%Y-%m-%d_%H%M%S'))
         proc = ExecuteProcess(
             cmd=['ros2', 'bag', 'record', '-o', bag_dir, '-a'],
             output='screen',
             shell='true'
             )
-
         return [proc]
+    else:
+        return []
 
 
 def on_shutdown(event, context):
-    params_file = os.path.join(get_package_share_directory("c1t_bringup"), "params", "params.yaml")
-    shutil.copy(params_file, bag_dir)
+    if record_bag == "true":
+        params_file = os.path.join(get_package_share_directory("c1t_bringup"), "params", "params.yaml")
+        shutil.copy(params_file, bag_dir)
 
 def generate_launch_description():
+    record_bag_arg = DeclareLaunchArgument(
+        "record_bag", default_value=TextSubstitution(text="false")
+    )
     return LaunchDescription([
+        record_bag_arg,
         OpaqueFunction(function=record_ros2_rosbag),
         RegisterEventHandler(
             OnShutdown(on_shutdown=on_shutdown)


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

This PR adds logic to optionally record a ROS2 bag on the C1T trucks during system bringup. The parameters used for each bag are also copied to the bag directory.

## Related Jira Key

[CF-878](https://usdot-carma.atlassian.net/browse/CF-878)

## Motivation and Context

In order to track how parameter changes impact system performance, we need to record data from the vehicle for future analysis and ensure that the parameters used for each run are tracked as well.

## How Has This Been Tested?

Launching `c1t_bringup_launch.xml` with `record_rosbag:=true` results in a bag recorded to `~/bags/rosbag2_YYYY-MM-DD-HH-MM-SS/` and the current parameters file copied to the same directory. If not set or set to anything other than `true`, a bag is not recorded.

## Types of changes

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[CF-878]: https://usdot-carma.atlassian.net/browse/CF-878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ