### PR TITLE
CF 876 added dependencies to package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -9,7 +9,15 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>ament_cmake_auto</build_depend>
+  <depend>ament_cmake_auto</depend>
+  <depend>vesc</depend>
+  <depend>twist_to_ackermann</depend>
+  <depend>sllidar_ros2</depend>
+  <depend>laser_filters</depend>
+  <depend>navigation2</depend>
+  <depend>nav2_route</depend>
+  <depend>tf2_ros</depend>
+  <depend>teleop_twist_joy</depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
# PR Details
## Description

This PR adds the dependencies for the c1t_bringup to the package.xml.

## Related Jira Key

[CF-876](https://usdot-carma.atlassian.net/browse/CF-876)

## Motivation and Context

All of the packages needed to run `c1t_bringup_launch.xml` can now be build by running `colcon build --packages-up-to c1t_bringup` instead of having to manually build each package.

## How Has This Been Tested?

I removed the `install/`, `build/`, and `log/` folders to clear build cache, ran `colcon build --packages-up-to c1t_bringup` and was able to successfully launch `c1t_bringup_launch.xml` after the build completed.

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[CF-876]: https://usdot-carma.atlassian.net/browse/CF-876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ