### PR TITLE
added parameter for port drayage cmv_id

### DIFF
--- a/launch/navigation_launch.xml
+++ b/launch/navigation_launch.xml
@@ -20,7 +20,9 @@
 
   <node pkg="nav2_waypoint_follower" exec="waypoint_follower"/>
 
-  <node pkg="carma_nav2_port_drayage_demo" exec="carma_nav2_port_drayage_demo_node"/>
+  <node pkg="carma_nav2_port_drayage_demo" exec="carma_nav2_port_drayage_demo_node">
+    <param from="$(find-pkg-share c1t_bringup)/params/$(var vehicle)_params.yaml"/>
+  </node>
 
   <node pkg="nav2_route" exec="route_server">
     <param from="$(find-pkg-share c1t_bringup)/params/$(var vehicle)_params.yaml"/>

--- a/params/blue_truck_params.yaml
+++ b/params/blue_truck_params.yaml
@@ -280,3 +280,7 @@ vesc_driver_node:
     servo_min: 0.00
     speed_max: 23250.0
     speed_min: -23250.0
+
+port_drayage_demo:
+  ros__parameters:
+    cmv_id: "blue_truck"

--- a/params/red_truck_params.yaml
+++ b/params/red_truck_params.yaml
@@ -280,3 +280,7 @@ vesc_driver_node:
     servo_min: 0.00
     speed_max: 23250.0
     speed_min: -23250.0
+
+port_drayage_demo:
+  ros__parameters:
+    cmv_id: "red_truck"

--- a/params/turtlebot_params.yaml
+++ b/params/turtlebot_params.yaml
@@ -104,7 +104,7 @@ controller_server:
     min_theta_velocity_threshold: 0.001
     failure_tolerance: 0.3
     progress_checker_plugin: "progress_checker"
-    goal_checker_plugins: ["general_goal_checker"] 
+    goal_checker_plugins: ["general_goal_checker"]
     controller_plugins: ["FollowPath"]
 
     # Progress checker parameters
@@ -112,7 +112,7 @@ controller_server:
       plugin: "nav2_controller::SimpleProgressChecker"
       required_movement_radius: 0.5
       movement_time_allowance: 10.0
-    
+
     general_goal_checker:
       stateful: True
       plugin: "nav2_controller::SimpleGoalChecker"
@@ -161,7 +161,7 @@ controller_server:
       RotateToGoal.scale: 32.0
       RotateToGoal.slowing_factor: 5.0
       RotateToGoal.lookahead_time: -1.0
-      
+
 controller_server_rclcpp_node:
   ros__parameters:
     use_sim_time: False
@@ -342,7 +342,7 @@ waypoint_follower:
   ros__parameters:
     loop_rate: 2000
     stop_on_failure: false
-    waypoint_task_executor_plugin: "wait_at_waypoint"   
+    waypoint_task_executor_plugin: "wait_at_waypoint"
     wait_at_waypoint:
       plugin: "nav2_waypoint_follower::WaitAtWaypoint"
       enabled: True
@@ -371,3 +371,7 @@ route_server:
 
     CostmapScorer:
       plugin: "nav2_route::CostmapScorer"
+
+port_drayage_demo:
+  ros__parameters:
+    cmv_id: "turtlebot"


### PR DESCRIPTION
# PR Details
## Description

This PR adds the configurable `cmv_id` parameter to the params files for the C1T trucks and turtlebot simulator.

Related PR: [navigation2_extensions #6](https://github.com/usdot-fhwa-stol/navigation2_extensions/pull/6)

## Related Jira Key

[CF-866](https://usdot-carma.atlassian.net/browse/CF-866)

## Motivation and Context

The carma_nav2_port_drayage_demo package was recently updated in [CF-852](https://usdot-carma.atlassian.net/browse/CF-852)  to handle processing of received port drayage-related Mobility Operation messages from infrastructure, and to publish port drayage Mobility Operation messages upon arrival at a destination. This implementation has some hardcoded values, and the package should be updated to better handle some of these variables, while also making some configurable if necessary.

## How Has This Been Tested?

This was tested using the turtlebot simulator and sending Mobility Operation messages to instruct the vehicle to pickup and dropoff cargo. Upon picking up cargo, the vehicle acknowledged that it was carrying cargo with the correct cargo id. After dropping off the cargo, it then acknowledged that is was no longer carrying cargo. Additionally, if Mobility Operation messages were sent with the wrong `cmv_id`, the vehicle disregarded the message.

## Types of changes

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[CF-866]: https://usdot-carma.atlassian.net/browse/CF-866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CF-852]: https://usdot-carma.atlassian.net/browse/CF-852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ