### PR TITLE
CF 884 Fix Warning Message on Build

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -10,9 +10,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>ament_cmake_auto</depend>
-  <depend>vesc</depend>
   <depend>twist_to_ackermann</depend>
-  <depend>sllidar_ros2</depend>
   <depend>laser_filters</depend>
   <depend>navigation2</depend>
   <depend>nav2_route</depend>


### PR DESCRIPTION
# PR Details
## Description

This PR fixes the warning message that appears when building `c1t_bringup`.

## Related Jira Key

[CF-884](https://usdot-carma.atlassian.net/browse/CF-884)

## Motivation and Context

Warning messages are bad.

## How Has This Been Tested?

The package was rebuilt after removing it from `include/` and `build/` and the warning message did not appear.

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[CF-884]: https://usdot-carma.atlassian.net/browse/CF-884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ