### PR TITLE
CS 882 Update Transforms Launch to Use URDF for Specified Vehicle

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,4 +9,5 @@ ament_auto_package(
     launch
     params
     maps
+    urdf
 )

--- a/launch/c1t_bringup_launch.xml
+++ b/launch/c1t_bringup_launch.xml
@@ -4,7 +4,9 @@
 
   <!--Launch files exclusive to C1T trucks-->
   <include file="$(find-pkg-share c1t_bringup)/launch/teleop_launch.xml" unless="$(eval '\'$(var vehicle)\' == \'turtlebot\'')"/>
-  <include file="$(find-pkg-share c1t_bringup)/launch/transforms_launch.xml" unless="$(eval '\'$(var vehicle)\' == \'turtlebot\'')"/>
+  <include file="$(find-pkg-share c1t_bringup)/launch/transforms_launch.xml" unless="$(eval '\'$(var vehicle)\' == \'turtlebot\'')">
+    <arg name="vehicle" value="$(var vehicle)"/>
+  </include>
   <include file="$(find-pkg-share c1t_bringup)/launch/drivers_launch.xml" unless="$(eval '\'$(var vehicle)\' == \'turtlebot\'')">
     <arg name="vehicle" value="$(var vehicle)"/>
   </include>

--- a/launch/transforms_launch.xml
+++ b/launch/transforms_launch.xml
@@ -1,22 +1,12 @@
 <launch>
-  <node 
-    pkg="tf2_ros" 
-    exec="static_transform_publisher" 
-    name="base_link_to_laser"
-    args="--x 0.447675 --z 0.143 --yaw 3.0805061 --frame-id base_link --child-frame-id laser"
+
+  <arg name="vehicle" description="red_truck, blue_truck, or turtlebot"/>
+
+  <node
+    pkg="robot_state_publisher"
+    exec="robot_state_publisher"
+    name="robot_state_publisher"
+    args="$(find-pkg-share c1t_bringup)/urdf/$(var vehicle).urdf"
   />
 
-  <node 
-    pkg="tf2_ros" 
-    exec="static_transform_publisher" 
-    name="base_link_to_footprint"
-    args="--z -0.043 --frame-id base_link --child-frame-id base_footprint"
-  />
-
-  <node 
-    pkg="tf2_ros" 
-    exec="static_transform_publisher" 
-    name="base_link_to_coat_hanger"
-    args="--x 0.9869 --frame-id base_link --child-frame-id coat_hanger"
-  />
 </launch>

--- a/urdf/blue_truck.urdf
+++ b/urdf/blue_truck.urdf
@@ -1,6 +1,6 @@
 <robot name="red_truck">
   <link name="base_link" />
-  <link name="footprint" />
+  <link name="base_footprint" />
   <link name="imu" />
   <link name="laser" />
 
@@ -19,7 +19,7 @@
 
   <joint name="footprint_joint" type="fixed">
     <parent link="base_link"/>
-    <child link="footprint"/>
+    <child link="base_footprint"/>
     <origin xyz="0 0 -0.043" />
   </joint>
 

--- a/urdf/red_truck.urdf
+++ b/urdf/red_truck.urdf
@@ -1,6 +1,6 @@
 <robot name="red_truck">
   <link name="base_link" />
-  <link name="footprint" />
+  <link name="base_footprint" />
   <link name="imu" />
   <link name="laser" />
 
@@ -19,7 +19,7 @@
 
   <joint name="footprint_joint" type="fixed">
     <parent link="base_link"/>
-    <child link="footprint"/>
+    <child link="base_footprint"/>
     <origin xyz="0 0 -0.043" />
   </joint>
 


### PR DESCRIPTION
# PR Details
## Description

So far we have been using the same static transforms for the red and blue trucks despite their measurements being different. This PR updates `transforms_launch.xml` to use the urdf file of the specified vehicle.

## Related Jira Key

[CF-882](https://usdot-carma.atlassian.net/browse/CF-882)

## Motivation and Context

The vehicles should perform better when their static transforms are accurate, so it is important that we use the measured dimensions for each vehicle.

## How Has This Been Tested?

When running `c1t_bringup_launch.xml`, the transformations from `blue_truck.urdf` load when `vehicle:=blue_truck` is specified as a launch argument, and vice versa for `red_truck`.

## Types of changes

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[CF-882]: https://usdot-carma.atlassian.net/browse/CF-882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ