### PR TITLE
added emergency stop node to navigation launch file

### DIFF
--- a/launch/navigation_launch.xml
+++ b/launch/navigation_launch.xml
@@ -35,4 +35,11 @@
       value="bt_navigator, planner_server, controller_server, behavior_server, smoother_server, waypoint_follower, route_server, port_drayage_demo"
       value-sep=", "/>
   </node>
+
+  <node pkg="carma_nav2_emergency_stop" exec="carma_nav2_emergency_stop_node" name="carma_nav2_emergency_stop_node">
+    <param
+      name="node_names"
+      value="bt_navigator, controller_server, behavior_server, smoother_server, waypoint_follower, route_server, port_drayage_demo"
+      value-sep=", "/>
+  </node>
 </launch>

--- a/launch/teleop_launch.xml
+++ b/launch/teleop_launch.xml
@@ -3,7 +3,7 @@
     <param name="axis_linear.x" value="1"/>
     <param name="scale_linear.x" value="1.0"/>
     <param name="axis_angular.yaw" value="0"/>
-    <param name="sale_angular.yaw" value="0.5"/>
+    <param name="scale_angular.yaw" value="0.5"/>
     <param name="enable_button" value="5"/>
   </node>
 </launch>

--- a/package.xml
+++ b/package.xml
@@ -19,6 +19,7 @@
   <depend>dsrc_driver</depend>
   <depend>cpp_message</depend>
   <depend>carma_nav2_port_drayage_demo</depend>
+  <depend>carma_nav2_emergency_stop</depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
# PR Details
## Description

This PR adds the emergency stop node to the navigation launch file.

Related PR: https://github.com/usdot-fhwa-stol/navigation2_extensions/pull/9
## Related GitHub Issue

NA

## Related Jira Key

[CF-899](https://usdot-carma.atlassian.net/browse/CF-899)

## Motivation and Context

Currently the only way to stop the C1T system during operation is to manually send a CTRL+C command to the terminal where the c1t_bringup launch has been called. Since several terminals may be open at a given time the vehicle may not be immediately stopped in cases where control is lost. A C1T E-stop should be enabled on a controller so that a developer can quickly stop the vehicle as soon as an issue is identified to prevent collisions.

## How Has This Been Tested?

IN PROGRESS - Currently shown to shutdown nav2 and send an empty AckermannDrive message when the Logitech button is pushed. Next steps will be testing on the vehicle to confirm it stops and will no longer drive.

## Types of changes

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[CF-899]: https://usdot-carma.atlassian.net/browse/CF-899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ