### PR TITLE
Fix Rviz and Add Gazebo to Turtlebot Launch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,4 +10,5 @@ ament_auto_package(
     params
     maps
     urdf
+    rviz
 )

--- a/launch/c1t_bringup_launch.xml
+++ b/launch/c1t_bringup_launch.xml
@@ -16,7 +16,6 @@
 
   <node pkg="rviz2" exec="rviz2" name="rviz" args="--display-config $(find-pkg-share c1t_bringup)/rviz/nav2_route.rviz" if="$(eval '\'$(var vehicle)\' == \'turtlebot\'')"/>
 
-
   <!--Common launch files-->
   <include file="$(find-pkg-share c1t_bringup)/launch/localization_launch.xml">
     <arg name="vehicle" value="$(var vehicle)"/>

--- a/launch/c1t_bringup_launch.xml
+++ b/launch/c1t_bringup_launch.xml
@@ -12,7 +12,10 @@
   </include>
 
   <!--Launch files exclusive to Turtlebot simulator-->
+  <include file="$(find-pkg-share turtlebot3_gazebo)/launch/turtlebot3_world.launch.py" if="$(eval '\'$(var vehicle)\' == \'turtlebot\'')"/>
+
   <node pkg="rviz2" exec="rviz2" name="rviz" args="--display-config $(find-pkg-share c1t_bringup)/rviz/nav2_route.rviz" if="$(eval '\'$(var vehicle)\' == \'turtlebot\'')"/>
+
 
   <!--Common launch files-->
   <include file="$(find-pkg-share c1t_bringup)/launch/localization_launch.xml">


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

This PR fixes an issue that prevents the correct Rviz config from launching when using the turtlebot simulator. It also adds the launch file used to start the Gazebo simulator to the bringup launch.

## Related GitHub Issue

## Related Jira Key

## Motivation and Context

## How Has This Been Tested?

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
