### PR TITLE
remapped cmd_vel to cmd_vel_smoothed

### DIFF
--- a/launch/drivers_launch.xml
+++ b/launch/drivers_launch.xml
@@ -13,6 +13,7 @@
 
   <node pkg="twist_to_ackermann" exec="twist_to_ackermann_node" name="twist_to_ackermann_node">
     <remap from="/ackermann" to="/ackermann_cmd"/>
+    <remap from="/cmd_vel" to="/cmd_vel_smoothed"/>
   </node>
 
   <node pkg="sllidar_ros2" exec="sllidar_node" name="sllidar_node">

--- a/launch/teleop_launch.xml
+++ b/launch/teleop_launch.xml
@@ -5,5 +5,6 @@
     <param name="axis_angular.yaw" value="0"/>
     <param name="scale_angular.yaw" value="0.5"/>
     <param name="enable_button" value="5"/>
+    <remap from="/cmd_vel" to="/cmd_vel_smoothed"/>
   </node>
 </launch>


### PR DESCRIPTION

# PR Details
## Description

This PR remaps the topic `/cmd_vel` to `/cmd_vel_smoothed` since this is what the recently added velocity smoother publishes on.

## Related GitHub Issue

## Related Jira Key

## Motivation and Context

This configures the `twist_to_ackermann_node` and `teleop_node`  to subscribe and publish on the correct topic.

## How Has This Been Tested?

Tested in the turtlebot simulator and on the blue truck.

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
