### PR TITLE
Cf 938 stop closer to goal

### DIFF
--- a/params/blue_truck_params.yaml
+++ b/params/blue_truck_params.yaml
@@ -160,10 +160,9 @@ controller_server:
       plugin: "nav2_controller::SimpleProgressChecker"
 
     general_goal_checker:
-      plugin: "nav2_controller::StoppedGoalChecker"
+      plugin: "nav2_controller::SimpleGoalChecker"
       xy_goal_tolerance: 0.4
       yaw_goal_tolerance: 3.14
-      trans_stopped_velocity: 0.05
 
     FollowPath:
       plugin: "nav2_regulated_pure_pursuit_controller::RegulatedPurePursuitController"

--- a/params/blue_truck_params.yaml
+++ b/params/blue_truck_params.yaml
@@ -160,9 +160,10 @@ controller_server:
       plugin: "nav2_controller::SimpleProgressChecker"
 
     general_goal_checker:
-      plugin: "nav2_controller::SimpleGoalChecker"
+      plugin: "nav2_controller::StoppedGoalChecker"
       xy_goal_tolerance: 0.4
       yaw_goal_tolerance: 3.14
+      trans_stopped_velocity: 0.05
 
     FollowPath:
       plugin: "nav2_regulated_pure_pursuit_controller::RegulatedPurePursuitController"
@@ -171,6 +172,9 @@ controller_server:
       use_rotate_to_heading: false
       inflation_cost_scaling_factor: 1.0
       lookahead_dist: 0.75
+      approach_velocity_scaling_dist: 0.3
+      use_fixed_curvature_lookahead: true
+      interpolate_curvature_after_goal: true
 
 waypoint_follower:
   ros__parameters:

--- a/params/blue_truck_params.yaml
+++ b/params/blue_truck_params.yaml
@@ -161,19 +161,19 @@ controller_server:
 
     general_goal_checker:
       plugin: "nav2_controller::SimpleGoalChecker"
-      xy_goal_tolerance: 0.4
-      yaw_goal_tolerance: 3.14
+      xy_goal_tolerance: 0.4 # Translational tolerance to meet goal completion criteria
+      yaw_goal_tolerance: 3.14 # Rotational tolerance to meet goal completion criteria
 
     FollowPath:
       plugin: "nav2_regulated_pure_pursuit_controller::RegulatedPurePursuitController"
-      desired_linear_vel: 0.5
+      desired_linear_vel: 0.5 # The desired maximum linear velocity
       use_collision_detection: false # Set to off due to poor collision estimate behavior
-      use_rotate_to_heading: false
+      use_rotate_to_heading: false # Recommended on for all robot types that can rotate in place
       inflation_cost_scaling_factor: 1.0
-      lookahead_dist: 0.75
-      approach_velocity_scaling_dist: 0.3
-      use_fixed_curvature_lookahead: true
-      interpolate_curvature_after_goal: true
+      lookahead_dist: 0.75 # The lookahead distance (m) to use to find the lookahead point
+      approach_velocity_scaling_dist: 0.3 # The distance (m) left on the path at which to start slowing down.
+      use_fixed_curvature_lookahead: true # Whether to use a fixed lookahead distance to compute curvature from
+      interpolate_curvature_after_goal: true # Interpolate a carrot after the goal dedicated to the curvate calculation (to avoid oscilaltions at the end of the path)
 
 waypoint_follower:
   ros__parameters:
@@ -227,20 +227,20 @@ vesc_to_odom_node:
   ros__parameters:
     odom_frame: odom
     base_frame: base_link
-    speed_to_erpm_gain: 4100.0
-    speed_to_erpm_offset: 0.0
-    use_servo_cmd_to_calc_angular_velocity: True
-    steering_angle_to_servo_gain: -0.94
-    steering_angle_to_servo_offset: 0.425
+    speed_to_erpm_gain: 4100.0 # Gain tuned to scale speed to ERPM
+    speed_to_erpm_offset: 0.0 # Offset for converting speed to ERPM
+    use_servo_cmd_to_calc_angular_velocity: True # Use servo to calculate angular velocity
+    steering_angle_to_servo_gain: -0.94 # Gain tuned to scale steering angle to servo command
+    steering_angle_to_servo_offset: 0.425 # Offset for converting steering angle to servo command
     wheelbase: 0.43
     publish_tf: True
 
 ackermann_to_vesc_node:
   ros__parameters:
-    speed_to_erpm_gain: 4100.0
-    speed_to_erpm_offset: 0.0
-    steering_angle_to_servo_gain: 0.55
-    steering_angle_to_servo_offset: 0.425
+    speed_to_erpm_gain: 4100.0 # Gain tuned to scale speed to ERPM
+    speed_to_erpm_offset: 0.0 # Offset for converting speed to ERPM
+    steering_angle_to_servo_gain: 0.55 # Gain tuned to scale steering angle to servo command
+    steering_angle_to_servo_offset: 0.425 # Offset for converting steering angle to servo command
     Kp: 0.8
     Ki: 0.15
     Kd: 0.0
@@ -263,5 +263,5 @@ vesc_driver_node:
 
 port_drayage_demo:
   ros__parameters:
-    cmv_id: "C1T-1"
-    message_processing_delay: 0
+    cmv_id: "C1T-1" # Vehicle's ID for Port Drayage use case (ID must match on infrastructure side)
+    message_processing_delay: 0 # Time to wait after receiving a new command before driving

--- a/params/red_truck_params.yaml
+++ b/params/red_truck_params.yaml
@@ -161,19 +161,19 @@ controller_server:
 
     general_goal_checker:
       plugin: "nav2_controller::SimpleGoalChecker"
-      xy_goal_tolerance: 0.4
-      yaw_goal_tolerance: 3.14
+      xy_goal_tolerance: 0.4 # Translational tolerance to meet goal completion criteria
+      yaw_goal_tolerance: 3.14 # Rotational tolerance to meet goal completion criteria
 
     FollowPath:
       plugin: "nav2_regulated_pure_pursuit_controller::RegulatedPurePursuitController"
-      desired_linear_vel: 0.5
+      desired_linear_vel: 0.5 # The desired maximum linear velocity
       use_collision_detection: false # Set to off due to poor collision estimate behavior
-      use_rotate_to_heading: false
+      use_rotate_to_heading: false # Recommended on for all robot types that can rotate in place
       inflation_cost_scaling_factor: 1.0
-      lookahead_dist: 0.75
-      approach_velocity_scaling_dist: 0.3
-      use_fixed_curvature_lookahead: true
-      interpolate_curvature_after_goal: true
+      lookahead_dist: 0.75 # The lookahead distance (m) to use to find the lookahead point
+      approach_velocity_scaling_dist: 0.3 # The distance (m) left on the path at which to start slowing down.
+      use_fixed_curvature_lookahead: true # Whether to use a fixed lookahead distance to compute curvature from
+      interpolate_curvature_after_goal: true # Interpolate a carrot after the goal dedicated to the curvate calculation (to avoid oscilaltions at the end of the path)
 
 waypoint_follower:
   ros__parameters:
@@ -227,20 +227,20 @@ vesc_to_odom_node:
   ros__parameters:
     odom_frame: odom
     base_frame: base_link
-    speed_to_erpm_gain: 4100.0
-    speed_to_erpm_offset: 0.0
-    use_servo_cmd_to_calc_angular_velocity: True
-    steering_angle_to_servo_gain: 0.94
-    steering_angle_to_servo_offset: 0.425
+    speed_to_erpm_gain: 4100.0 # Gain tuned to scale speed to ERPM
+    speed_to_erpm_offset: 0.0 # Offset for converting speed to ERPM
+    use_servo_cmd_to_calc_angular_velocity: True # Use servo to calculate angular velocity
+    steering_angle_to_servo_gain: 0.94 # Gain tuned to scale steering angle to servo command
+    steering_angle_to_servo_offset: 0.425 # Offset for converting steering angle to servo command
     wheelbase: 0.43
     publish_tf: True
 
 ackermann_to_vesc_node:
   ros__parameters:
-    speed_to_erpm_gain: 4100.0
-    speed_to_erpm_offset: 0.0
-    steering_angle_to_servo_gain: -0.55
-    steering_angle_to_servo_offset: 0.425
+    speed_to_erpm_gain: 4100.0 # Gain tuned to scale speed to ERPM
+    speed_to_erpm_offset: 0.0 # Offset for converting speed to ERPM
+    steering_angle_to_servo_gain: -0.55 # Gain tuned to scale steering angle to servo command
+    steering_angle_to_servo_offset: 0.425 # Offset for converting steering angle to servo command
     Kp: 0.8
     Ki: 0.15
     Kd: 0.0
@@ -263,5 +263,5 @@ vesc_driver_node:
 
 port_drayage_demo:
   ros__parameters:
-    cmv_id: "C1T-1"
-    message_processing_delay: 0
+    cmv_id: "C1T-1" # Vehicle's ID for Port Drayage use case (ID must match on infrastructure side)
+    message_processing_delay: 0 # Time to wait after receiving a new command before driving

--- a/params/red_truck_params.yaml
+++ b/params/red_truck_params.yaml
@@ -230,7 +230,7 @@ vesc_to_odom_node:
     speed_to_erpm_gain: 4100.0 # Gain tuned to scale speed to ERPM
     speed_to_erpm_offset: 0.0 # Offset for converting speed to ERPM
     use_servo_cmd_to_calc_angular_velocity: True # Use servo to calculate angular velocity
-    steering_angle_to_servo_gain: 0.94 # Gain tuned to scale steering angle to servo command
+    steering_angle_to_servo_gain: -0.94 # Gain tuned to scale steering angle to servo command
     steering_angle_to_servo_offset: 0.425 # Offset for converting steering angle to servo command
     wheelbase: 0.43
     publish_tf: True
@@ -239,7 +239,7 @@ ackermann_to_vesc_node:
   ros__parameters:
     speed_to_erpm_gain: 4100.0 # Gain tuned to scale speed to ERPM
     speed_to_erpm_offset: 0.0 # Offset for converting speed to ERPM
-    steering_angle_to_servo_gain: -0.55 # Gain tuned to scale steering angle to servo command
+    steering_angle_to_servo_gain: 0.55 # Gain tuned to scale steering angle to servo command
     steering_angle_to_servo_offset: 0.425 # Offset for converting steering angle to servo command
     Kp: 0.8
     Ki: 0.15

--- a/params/red_truck_params.yaml
+++ b/params/red_truck_params.yaml
@@ -160,8 +160,9 @@ controller_server:
       plugin: "nav2_controller::SimpleProgressChecker"
 
     general_goal_checker:
-      plugin: "nav2_controller::SimpleGoalChecker"
+      plugin: "nav2_controller::StoppedGoalChecker"
       xy_goal_tolerance: 0.4
+      trans_stopped_velocity: 0.01
       yaw_goal_tolerance: 3.14
 
     FollowPath:

--- a/params/red_truck_params.yaml
+++ b/params/red_truck_params.yaml
@@ -160,9 +160,8 @@ controller_server:
       plugin: "nav2_controller::SimpleProgressChecker"
 
     general_goal_checker:
-      plugin: "nav2_controller::StoppedGoalChecker"
+      plugin: "nav2_controller::SimpleGoalChecker"
       xy_goal_tolerance: 0.4
-      trans_stopped_velocity: 0.01
       yaw_goal_tolerance: 3.14
 
     FollowPath:
@@ -172,6 +171,9 @@ controller_server:
       use_rotate_to_heading: false
       inflation_cost_scaling_factor: 1.0
       lookahead_dist: 0.75
+      approach_velocity_scaling_dist: 0.3
+      use_fixed_curvature_lookahead: true
+      interpolate_curvature_after_goal: true
 
 waypoint_follower:
   ros__parameters:


### PR DESCRIPTION
# PR Details
## Description

This PR includes parameter changes that result in the vehicle stopping closer to its provided goal. The `approach_velocity_scaling_dist` parameter was added to instruct the vehicle to begin slowing down once within 0.3 m of the goal. This value was tuned based on the vehicles current max speed (`desired_linear_vel`) and deceleration limits (`max_decel`). If either of these parameters are changed in the future, the value of the `approach_velocity_scaling_dist` will need to be re-tuned.

## Related GitHub Issue

NA

## Related Jira Key

[CF-938](https://usdot-carma.atlassian.net/browse/CF-938)

## Motivation and Context

The C1T vehicle currently stops ~0.3 m prior to its specified goal on average. Ideally, we would like the stopping distance to be as close to the goal as possible (<10 cm).

## How Has This Been Tested?

Parameter changes were tested on the blue truck with ROS2 bag logging enabled. Based on the data collected in the bag, the vehicle now stops on average ~4 cm from the goal. The furthest recorded stopping distance was ~8 cm.

## Types of changes

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[CF-938]: https://usdot-carma.atlassian.net/browse/CF-938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ