### PR TITLE
renamed c1t -> cda1tenth

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.22)
-project(c1t_bringup)
+project(cda1tenth_bringup)
 
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# c1t_bringup
+# cda1tenth_bringup
 
-This package contains the launch and configuration files needed to bring up a physical or simulated C1T vehicle. Some functionality may depend on the companion packages from [navigation2_extensions](https://github.com/usdot-fhwa-stol/navigation2_extensions) which provides route server and CDA additions to the C1T system.
+This package contains the launch and configuration files needed to bring up a physical or simulated CDA1tenth vehicle. Some functionality may depend on the companion packages from [navigation2_extensions](https://github.com/usdot-fhwa-stol/navigation2_extensions) which provides route server and CDA additions to the CDA1tenth system.
 
 ## Prerequisites
 
-The following configuration steps must be completed before a C1T vehicle or simulation will be ready for bringup.
+The following configuration steps must be completed before a CDA1tenth vehicle or simulation will be ready for bringup.
 
 1. Download the `nav2_route_server` branch and build it from source, which can be found [here](https://github.com/usdot-fhwa-stol/navigation2/tree/nav2_route_server).
 
@@ -16,17 +16,17 @@ The following configuration steps must be completed before a C1T vehicle or simu
     > [NOTE]
     > See [1. udev Rules Setup](https://f1tenth.readthedocs.io/en/foxy_test/getting_started/firmware/drive_workspace.html#udev-rules-setup) in the F1Tenth build documentation for details.
 
-3. Source the Nav2 install for future terminal instances with `echo 'source /home/$USER/c1t_ws/install/setup.bash' >> ~/.bashrc`
+3. Source the Nav2 install for future terminal instances with `echo 'source /home/$USER/cda_ws/install/setup.bash' >> ~/.bashrc`
 
 4. A map and route graph will need to be created for physical test environments. The `turtlebot` configuration includes these for reference. Maps can be created using [slam_toolbox](https://github.com/SteveMacenski/slam_toolbox) and graphs should follow the examples given in this package. New maps and graphs will need to manually updated in the launch and parameter files.
 
 
 ## Launch
 
-Run the following command to launch the C1T system:
+Run the following command to launch the CDA1tenth system:
 
 ```
-$ ros2 launch c1t_bringup c1t_bringup_launch.xml vehicle:=[red_truck, blue_truck, turtlebot] record_bag:=[true, false]
+$ ros2 launch cda1tenth_bringup cda1tenth_bringup_launch.xml vehicle:=[red_truck, blue_truck, turtlebot] record_bag:=[true, false]
 ```
 
 This will launch all necessary subsystems, such as drivers, localization, and navigation.
@@ -34,16 +34,16 @@ This will launch all necessary subsystems, such as drivers, localization, and na
 ### Launch Arguments
 - `vehicle` controls the parameter file used to launch the system and requires an input
 
-  - `red_truck` and `blue_truck` target parameter files specific to their respective C1T vehicles
+  - `red_truck` and `blue_truck` target parameter files specific to their respective CDA1tenth vehicles
 
-  - `turtlebot` runs a Gazebo-based simulation that allows for running core `c1t_bringup` packages locally without hardware interface nodes
+  - `turtlebot` runs a Gazebo-based simulation that allows for running core `cda1tenth_bringup` packages locally without hardware interface nodes
 
-- `record_bag` is a boolean argument for recording all data from the system in a ROS2 rosbag and defaults to `false`. Bags are saved in `~/c1t_bags` along with a copy of the parameter file used
+- `record_bag` is a boolean argument for recording all data from the system in a ROS2 rosbag and defaults to `false`. Bags are saved in `~/cda_bags` along with a copy of the parameter file used
 
 
 ## Post launch
 
-After launching the nodes included in `c1t_bringup`, additional actions are needed to finalize the system on a physical vehicle.
+After launching the nodes included in `cda1tenth_bringup`, additional actions are needed to finalize the system on a physical vehicle.
 
 1. Send an empty message to the `/ackermann_cmd` topic to initialize the VESC by publishing via command line on the vehicle with `ros2 pub /ackermann_cmd ackermann_msgs/msg/AckermannDriveStamped`. Use `CTRL + C` after a few have sent and the original terminal output has updated.
 
@@ -54,10 +54,10 @@ After launching the nodes included in `c1t_bringup`, additional actions are need
 
 3. In RViz, set the vehicle's initial pose estimate by selecting the `2D Pose Estimate` button at the top and drawing the approximate pose of the vehicle with respect to the map. The ROS2 nodes being used by the vehicle should be visualized after the estimate is drawn.
 
-4. A navigation command can now be sent to the C1T vehicle by using the `2D Goal Pose` button to draw a goal pose on the map using the RViz GUI.
+4. A navigation command can now be sent to the CDA1tenth vehicle by using the `2D Goal Pose` button to draw a goal pose on the map using the RViz GUI.
 
 ### Shutdown 
-To shut down the system, use `CTRL + C` on the `c1t_bringup` and `rviz2` terminals. Run `ros2 node list` to verify all nodes are shut down before relaunching the system.
+To shut down the system, use `CTRL + C` on the `cda1tenth_bringup` and `rviz2` terminals. Run `ros2 node list` to verify all nodes are shut down before relaunching the system.
 
 ## Contribution
 Welcome to the CARMA contributing guide. Please read this guide to learn about our development process, how to propose pull requests and improvements, and how to build and test your changes to this project. [CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # cda1tenth_bringup
 
-This package contains the launch and configuration files needed to bring up a physical or simulated CDA1tenth vehicle. Some functionality may depend on the companion packages from [navigation2_extensions](https://github.com/usdot-fhwa-stol/navigation2_extensions) which provides route server and CDA additions to the CDA1tenth system.
+This package contains the launch and configuration files needed to bring up a physical or simulated CDA1Tenth vehicle. Some functionality may depend on the companion packages from [navigation2_extensions](https://github.com/usdot-fhwa-stol/navigation2_extensions) which provides route server and CDA additions to the CDA1Tenth system.
 
 ## Prerequisites
 
-The following configuration steps must be completed before a CDA1tenth vehicle or simulation will be ready for bringup.
+The following configuration steps must be completed before a CDA1Tenth vehicle or simulation will be ready for bringup.
 
 1. Download the `nav2_route_server` branch and build it from source, which can be found [here](https://github.com/usdot-fhwa-stol/navigation2/tree/nav2_route_server).
 
@@ -23,7 +23,7 @@ The following configuration steps must be completed before a CDA1tenth vehicle o
 
 ## Launch
 
-Run the following command to launch the CDA1tenth system:
+Run the following command to launch the CDA1Tenth system:
 
 ```
 $ ros2 launch cda1tenth_bringup cda1tenth_bringup_launch.xml vehicle:=[red_truck, blue_truck, turtlebot] record_bag:=[true, false]
@@ -34,7 +34,7 @@ This will launch all necessary subsystems, such as drivers, localization, and na
 ### Launch Arguments
 - `vehicle` controls the parameter file used to launch the system and requires an input
 
-  - `red_truck` and `blue_truck` target parameter files specific to their respective CDA1tenth vehicles
+  - `red_truck` and `blue_truck` target parameter files specific to their respective CDA1Tenth vehicles
 
   - `turtlebot` runs a Gazebo-based simulation that allows for running core `cda1tenth_bringup` packages locally without hardware interface nodes
 
@@ -54,7 +54,7 @@ After launching the nodes included in `cda1tenth_bringup`, additional actions ar
 
 3. In RViz, set the vehicle's initial pose estimate by selecting the `2D Pose Estimate` button at the top and drawing the approximate pose of the vehicle with respect to the map. The ROS2 nodes being used by the vehicle should be visualized after the estimate is drawn.
 
-4. A navigation command can now be sent to the CDA1tenth vehicle by using the `2D Goal Pose` button to draw a goal pose on the map using the RViz GUI.
+4. A navigation command can now be sent to the CDA1Tenth vehicle by using the `2D Goal Pose` button to draw a goal pose on the map using the RViz GUI.
 
 ### Shutdown 
 To shut down the system, use `CTRL + C` on the `cda1tenth_bringup` and `rviz2` terminals. Run `ros2 node list` to verify all nodes are shut down before relaunching the system.

--- a/README.md
+++ b/README.md
@@ -45,16 +45,11 @@ This will launch all necessary subsystems, such as drivers, localization, and na
 
 After launching the nodes included in `cda1tenth_bringup`, additional actions are needed to finalize the system on a physical vehicle.
 
-1. Send an empty message to the `/ackermann_cmd` topic to initialize the VESC by publishing via command line on the vehicle with `ros2 pub /ackermann_cmd ackermann_msgs/msg/AckermannDriveStamped`. Use `CTRL + C` after a few have sent and the original terminal output has updated.
+1. If using a physical vehicle, RViz will need to be launched on an external PC on the same network and `ROS_DOMAIN_ID` as the vehicle. A specific RViz configuration is needed for visualizing and interacting with Nav2, which can be found in this package under the `rviz` directory. Run RViz in a terminal using the command `rviz2` and open this file using `File > Open Config`.
 
-   > [NOTE]
-   > The `vesc_to_odom_node` ROS node is responsible for publishing the odometry information it receives from the VESC motor controller. However, it does not start publishing this information until the VESC driver stack receives a command.
+2. In RViz, set the vehicle's initial pose estimate by selecting the `2D Pose Estimate` button at the top and drawing the approximate pose of the vehicle with respect to the map. The ROS2 nodes being used by the vehicle should be visualized after the estimate is drawn.
 
-2. If using a physical vehicle, RViz will need to be launched on an external PC on the same network and `ROS_DOMAIN_ID` as the vehicle. A specific RViz configuration is needed for visualizing and interacting with Nav2, which can be found in this package under the `rviz` directory. Run RViz in a terminal using the command `rviz2` and open this file using `File > Open Config`.
-
-3. In RViz, set the vehicle's initial pose estimate by selecting the `2D Pose Estimate` button at the top and drawing the approximate pose of the vehicle with respect to the map. The ROS2 nodes being used by the vehicle should be visualized after the estimate is drawn.
-
-4. A navigation command can now be sent to the CDA1Tenth vehicle by using the `2D Goal Pose` button to draw a goal pose on the map using the RViz GUI.
+3. A navigation command can now be sent to the CDA1Tenth vehicle by using the `2D Goal Pose` button to draw a goal pose on the map using the RViz GUI.
 
 ### Shutdown 
 To shut down the system, use `CTRL + C` on the `cda1tenth_bringup` and `rviz2` terminals. Run `ros2 node list` to verify all nodes are shut down before relaunching the system.

--- a/launch/cda1tenth_bringup_launch.xml
+++ b/launch/cda1tenth_bringup_launch.xml
@@ -2,7 +2,7 @@
   <arg name="record_bag" default="false" description="Record ROS2 bag to ~/cda_bags if true"/>
   <arg name="vehicle" description="red_truck, blue_truck, or turtlebot"/>
 
-  <!--Launch files exclusive to CDA1tenth trucks-->
+  <!--Launch files exclusive to CDA1Tenth trucks-->
   <include file="$(find-pkg-share cda1tenth_bringup)/launch/teleop_launch.xml" unless="$(eval '\'$(var vehicle)\' == \'turtlebot\'')"/>
   <include file="$(find-pkg-share cda1tenth_bringup)/launch/transforms_launch.xml" unless="$(eval '\'$(var vehicle)\' == \'turtlebot\'')">
     <arg name="vehicle" value="$(var vehicle)"/>

--- a/launch/cda1tenth_bringup_launch.xml
+++ b/launch/cda1tenth_bringup_launch.xml
@@ -1,33 +1,33 @@
 <launch>
-  <arg name="record_bag" default="false" description="Record ROS2 bag to ~/c1t_bags if true"/>
+  <arg name="record_bag" default="false" description="Record ROS2 bag to ~/cda_bags if true"/>
   <arg name="vehicle" description="red_truck, blue_truck, or turtlebot"/>
 
-  <!--Launch files exclusive to C1T trucks-->
-  <include file="$(find-pkg-share c1t_bringup)/launch/teleop_launch.xml" unless="$(eval '\'$(var vehicle)\' == \'turtlebot\'')"/>
-  <include file="$(find-pkg-share c1t_bringup)/launch/transforms_launch.xml" unless="$(eval '\'$(var vehicle)\' == \'turtlebot\'')">
+  <!--Launch files exclusive to CDA1tenth trucks-->
+  <include file="$(find-pkg-share cda1tenth_bringup)/launch/teleop_launch.xml" unless="$(eval '\'$(var vehicle)\' == \'turtlebot\'')"/>
+  <include file="$(find-pkg-share cda1tenth_bringup)/launch/transforms_launch.xml" unless="$(eval '\'$(var vehicle)\' == \'turtlebot\'')">
     <arg name="vehicle" value="$(var vehicle)"/>
   </include>
-  <include file="$(find-pkg-share c1t_bringup)/launch/drivers_launch.xml" unless="$(eval '\'$(var vehicle)\' == \'turtlebot\'')">
+  <include file="$(find-pkg-share cda1tenth_bringup)/launch/drivers_launch.xml" unless="$(eval '\'$(var vehicle)\' == \'turtlebot\'')">
     <arg name="vehicle" value="$(var vehicle)"/>
   </include>
 
   <!--Launch files exclusive to Turtlebot simulator-->
   <include file="$(find-pkg-share turtlebot3_gazebo)/launch/turtlebot3_world.launch.py" if="$(eval '\'$(var vehicle)\' == \'turtlebot\'')"/>
 
-  <node pkg="rviz2" exec="rviz2" name="rviz" args="--display-config $(find-pkg-share c1t_bringup)/rviz/nav2_route.rviz" if="$(eval '\'$(var vehicle)\' == \'turtlebot\'')"/>
+  <node pkg="rviz2" exec="rviz2" name="rviz" args="--display-config $(find-pkg-share cda1tenth_bringup)/rviz/nav2_route.rviz" if="$(eval '\'$(var vehicle)\' == \'turtlebot\'')"/>
 
   <!--Common launch files-->
-  <include file="$(find-pkg-share c1t_bringup)/launch/localization_launch.xml">
+  <include file="$(find-pkg-share cda1tenth_bringup)/launch/localization_launch.xml">
     <arg name="vehicle" value="$(var vehicle)"/>
   </include>
-  <include file="$(find-pkg-share c1t_bringup)/launch/navigation_launch.xml">
+  <include file="$(find-pkg-share cda1tenth_bringup)/launch/navigation_launch.xml">
     <arg name="vehicle" value="$(var vehicle)"/>
   </include>
   <include file="$(find-pkg-share dsrc_driver)/launch/dsrc_driver.py"/>
-  <include file="$(find-pkg-share c1t_bringup)/launch/cpp_message_launch.xml"/>
+  <include file="$(find-pkg-share cda1tenth_bringup)/launch/cpp_message_launch.xml"/>
 
   <!--Record ROS2 bag if record_bag:=true-->
-  <include file="$(find-pkg-share c1t_bringup)/launch/ros2_rosbag.launch.py" if="$(var record_bag)">
+  <include file="$(find-pkg-share cda1tenth_bringup)/launch/ros2_rosbag.launch.py" if="$(var record_bag)">
     <arg name="vehicle" value="$(var vehicle)"/>
   </include>
 

--- a/launch/drivers_launch.xml
+++ b/launch/drivers_launch.xml
@@ -1,14 +1,14 @@
 <launch>
   <node pkg="vesc_ackermann" exec="vesc_to_odom_node" name="vesc_to_odom_node">
-    <param from="$(find-pkg-share c1t_bringup)/params/$(var vehicle)_params.yaml"/>
+    <param from="$(find-pkg-share cda1tenth_bringup)/params/$(var vehicle)_params.yaml"/>
   </node>
 
   <node pkg="vesc_ackermann" exec="ackermann_to_vesc_node" name="ackermann_to_vesc_node">
-    <param from="$(find-pkg-share c1t_bringup)/params/$(var vehicle)_params.yaml"/>
+    <param from="$(find-pkg-share cda1tenth_bringup)/params/$(var vehicle)_params.yaml"/>
   </node>
 
   <node pkg="vesc_driver" exec="vesc_driver_node" name="vesc_driver_node">
-    <param from="$(find-pkg-share c1t_bringup)/params/$(var vehicle)_params.yaml"/>
+    <param from="$(find-pkg-share cda1tenth_bringup)/params/$(var vehicle)_params.yaml"/>
   </node>
 
   <node pkg="twist_to_ackermann" exec="twist_to_ackermann_node" name="twist_to_ackermann_node">
@@ -28,7 +28,7 @@
   </node>
 
   <node pkg="laser_filters" exec="scan_to_scan_filter_chain" name="scan_to_scan_filter_chain">
-    <param from="$(find-pkg-share c1t_bringup)/params/$(var vehicle)_params.yaml"/>
+    <param from="$(find-pkg-share cda1tenth_bringup)/params/$(var vehicle)_params.yaml"/>
     <remap from="/scan" to="/scan_raw"/>
     <remap from="/scan_filtered" to="/scan"/>
   </node>

--- a/launch/localization_launch.xml
+++ b/launch/localization_launch.xml
@@ -3,11 +3,11 @@
   <arg name="vehicle" description="red_truck, blue_truck, or turtlebot"/>
 
   <node pkg="nav2_map_server" exec="map_server" name="map_server">
-    <param name="yaml_filename" value="$(find-pkg-share c1t_bringup)/maps/garage.yaml"/>
+    <param name="yaml_filename" value="$(find-pkg-share cda1tenth_bringup)/maps/garage.yaml"/>
   </node>
 
   <node pkg="nav2_amcl" exec="amcl" name="amcl">
-    <param from="$(find-pkg-share c1t_bringup)/params/$(var vehicle)_params.yaml"/>
+    <param from="$(find-pkg-share cda1tenth_bringup)/params/$(var vehicle)_params.yaml"/>
   </node>
 
   <node pkg="nav2_lifecycle_manager" exec="lifecycle_manager" name="lifecycle_manager_localization">

--- a/launch/navigation_launch.xml
+++ b/launch/navigation_launch.xml
@@ -3,15 +3,15 @@
   <arg name="vehicle" description="red_truck, blue_truck, or turtlebot"/>
 
   <node pkg="nav2_bt_navigator" exec="bt_navigator">
-    <param from="$(find-pkg-share c1t_bringup)/params/$(var vehicle)_params.yaml"/>
+    <param from="$(find-pkg-share cda1tenth_bringup)/params/$(var vehicle)_params.yaml"/>
   </node>
 
   <node pkg="nav2_planner" exec="planner_server">
-    <param from="$(find-pkg-share c1t_bringup)/params/$(var vehicle)_params.yaml"/>
+    <param from="$(find-pkg-share cda1tenth_bringup)/params/$(var vehicle)_params.yaml"/>
   </node>
 
   <node pkg="nav2_controller" exec="controller_server">
-     <param from="$(find-pkg-share c1t_bringup)/params/$(var vehicle)_params.yaml"/>
+     <param from="$(find-pkg-share cda1tenth_bringup)/params/$(var vehicle)_params.yaml"/>
   </node>
 
   <node pkg="nav2_behaviors" exec="behavior_server"/>
@@ -19,17 +19,17 @@
   <node pkg="nav2_smoother" exec="smoother_server"/>
 
   <node pkg="nav2_velocity_smoother" exec="velocity_smoother">
-     <param from="$(find-pkg-share c1t_bringup)/params/$(var vehicle)_params.yaml"/>
+     <param from="$(find-pkg-share cda1tenth_bringup)/params/$(var vehicle)_params.yaml"/>
   </node>
 
   <node pkg="nav2_waypoint_follower" exec="waypoint_follower"/>
 
-  <node pkg="carma_nav2_port_drayage_demo" exec="carma_nav2_port_drayage_demo_node">
-    <param from="$(find-pkg-share c1t_bringup)/params/$(var vehicle)_params.yaml"/>
+  <node pkg="nav2_port_drayage_demo" exec="nav2_port_drayage_demo_node">
+    <param from="$(find-pkg-share cda1tenth_bringup)/params/$(var vehicle)_params.yaml"/>
   </node>
 
   <node pkg="nav2_route" exec="route_server">
-    <param from="$(find-pkg-share c1t_bringup)/params/$(var vehicle)_params.yaml"/>
+    <param from="$(find-pkg-share cda1tenth_bringup)/params/$(var vehicle)_params.yaml"/>
   </node>
 
   <node pkg="nav2_lifecycle_manager" exec="lifecycle_manager" name="lifecycle_manager_navigation">
@@ -40,7 +40,7 @@
       value-sep=", "/>
   </node>
 
-  <node pkg="carma_nav2_emergency_stop" exec="carma_nav2_emergency_stop_node" name="carma_nav2_emergency_stop_node">
+  <node pkg="nav2_emergency_stop" exec="nav2_emergency_stop_node" name="nav2_emergency_stop_node">
     <param
       name="node_names"
       value="bt_navigator, controller_server, behavior_server, smoother_server, velocity_smoother, waypoint_follower, route_server, port_drayage_demo"

--- a/launch/ros2_rosbag.launch.py
+++ b/launch/ros2_rosbag.launch.py
@@ -29,7 +29,7 @@ bag_dir = ''
 
 def record_ros2_rosbag(context: LaunchContext):
     global bag_dir
-    bag_dir = '/home/' + os.getlogin() + '/c1t_bags/rosbag2_' + str(datetime.now().strftime('%Y-%m-%d_%H%M%S'))
+    bag_dir = '/home/' + os.getlogin() + '/cda_bags/rosbag2_' + str(datetime.now().strftime('%Y-%m-%d_%H%M%S'))
     proc = ExecuteProcess(
         cmd=['ros2', 'bag', 'record', '-o', bag_dir, '-a'],
         output='screen',
@@ -39,7 +39,7 @@ def record_ros2_rosbag(context: LaunchContext):
 
 def on_shutdown(event, context):
     vehicle_name = LaunchConfiguration('vehicle').perform(context)
-    params_file = os.path.join(get_package_share_directory("c1t_bringup"), "params", vehicle_name + "_params.yaml")
+    params_file = os.path.join(get_package_share_directory("cda1tenth_bringup"), "params", vehicle_name + "_params.yaml")
     shutil.copy(params_file, bag_dir)
 
 def generate_launch_description():

--- a/launch/transforms_launch.xml
+++ b/launch/transforms_launch.xml
@@ -6,7 +6,7 @@
     pkg="robot_state_publisher"
     exec="robot_state_publisher"
     name="robot_state_publisher"
-    args="$(find-pkg-share c1t_bringup)/urdf/$(var vehicle).urdf"
+    args="$(find-pkg-share cda1tenth_bringup)/urdf/$(var vehicle).urdf"
   />
 
 </launch>

--- a/package.xml
+++ b/package.xml
@@ -3,7 +3,7 @@
 <package format="3">
   <name>cda1tenth_bringup</name>
   <version>0.0.0</version>
-  <description>Bringup scripts and configurations for CDA1tenth</description>
+  <description>Bringup scripts and configurations for CDA1Tenth</description>
   <maintainer email="carma@dot.gov">CARMA Support</maintainer>
   <license>Apache-2.0</license>
 

--- a/package.xml
+++ b/package.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-  <name>c1t_bringup</name>
+  <name>cda1tenth_bringup</name>
   <version>0.0.0</version>
-  <description>Bringup scripts and configurations for CARMA 1Tenth (C1T)</description>
+  <description>Bringup scripts and configurations for CDA1tenth</description>
   <maintainer email="carma@dot.gov">CARMA Support</maintainer>
   <license>Apache-2.0</license>
 
@@ -18,9 +18,9 @@
   <depend>teleop_twist_joy</depend>
   <depend>dsrc_driver</depend>
   <depend>cpp_message</depend>
-  <depend>carma_nav2_port_drayage_demo</depend>
-  <depend>carma_nav2_behavior_tree</depend>
-  <depend>carma_nav2_emergency_stop</depend>
+  <depend>nav2_port_drayage_demo</depend>
+  <depend>nav2_route_server_behavior_tree</depend>
+  <depend>nav2_emergency_stop</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/params/blue_truck_params.yaml
+++ b/params/blue_truck_params.yaml
@@ -44,11 +44,11 @@ bt_navigator:
     robot_base_frame: base_link
     odom_topic: odom
     navigators: ["navigate_to_pose"]
-    default_nav_to_pose_bt_xml: "/home/ubuntu/c1t_ws/src/c1t_bringup/behavior_trees/navigate_through_route_to_pose.xml"
+    default_nav_to_pose_bt_xml: "/home/ubuntu/cda_ws/src/cda1tenth_bringup/behavior_trees/navigate_through_route_to_pose.xml"
     navigate_to_pose:
       plugin: "nav2_bt_navigator/NavigateToPoseNavigator"
     plugin_lib_names:
-      - carma_nav2_compute_route_action_bt_node
+      - nav2_route_server_compute_route_action_bt_node
       - nav2_compute_path_to_pose_action_bt_node
       - nav2_compute_path_through_poses_action_bt_node
       - nav2_smooth_path_action_bt_node
@@ -193,7 +193,7 @@ velocity_smoother:
 
 route_server:
   ros__parameters:
-    graph_filepath: "/home/ubuntu/c1t_ws/src/c1t_bringup/graphs/garage_center_line.geojson"
+    graph_filepath: "/home/ubuntu/cda_ws/src/cda1tenth_bringup/graphs/garage_center_line.geojson"
     boundary_radius_to_achieve_node: 1.0
     radius_to_achieve_node: 2.0
     edge_cost_functions: ["DistanceScorer", "CostmapScorer"]
@@ -263,5 +263,5 @@ vesc_driver_node:
 
 port_drayage_demo:
   ros__parameters:
-    cmv_id: "C1T-1" # Vehicle's ID for Port Drayage use case (ID must match on infrastructure side)
+    cmv_id: "BLUE-TRUCK" # Vehicle's ID for Port Drayage use case (ID must match on infrastructure side)
     message_processing_delay: 0 # Time to wait after receiving a new command before driving

--- a/params/blue_truck_params.yaml
+++ b/params/blue_truck_params.yaml
@@ -44,7 +44,7 @@ bt_navigator:
     robot_base_frame: base_link
     odom_topic: odom
     navigators: ["navigate_to_pose"]
-    default_nav_to_pose_bt_xml: "/home/ubuntu/cda_ws/src/cda1tenth_bringup/behavior_trees/navigate_through_route_to_pose.xml"
+    default_nav_to_pose_bt_xml: "/home/ubuntu/cda_ws/src/cda1tenth-bringup/behavior_trees/navigate_through_route_to_pose.xml"
     navigate_to_pose:
       plugin: "nav2_bt_navigator/NavigateToPoseNavigator"
     plugin_lib_names:
@@ -193,7 +193,7 @@ velocity_smoother:
 
 route_server:
   ros__parameters:
-    graph_filepath: "/home/ubuntu/cda_ws/src/cda1tenth_bringup/graphs/garage_center_line.geojson"
+    graph_filepath: "/home/ubuntu/cda_ws/src/cda1tenth-bringup/graphs/garage_center_line.geojson"
     boundary_radius_to_achieve_node: 1.0
     radius_to_achieve_node: 2.0
     edge_cost_functions: ["DistanceScorer", "CostmapScorer"]

--- a/params/params.yaml
+++ b/params/params.yaml
@@ -44,7 +44,7 @@ bt_navigator:
     robot_base_frame: base_link
     odom_topic: odom
     navigators: ["navigate_to_pose"]
-    default_nav_to_pose_bt_xml: "/home/ubuntu/cda_ws/src/cda1tenth_bringup/behavior_trees/navigate_through_route_to_pose.xml"
+    default_nav_to_pose_bt_xml: "/home/ubuntu/cda_ws/src/cda1tenth-bringup/behavior_trees/navigate_through_route_to_pose.xml"
     navigate_to_pose:
       plugin: "nav2_bt_navigator/NavigateToPoseNavigator"
     plugin_lib_names:
@@ -214,7 +214,7 @@ waypoint_follower:
 
 route_server:
   ros__parameters:
-    graph_filepath: "/home/ubuntu/cda_ws/src/cda1tenth_bringup/graphs/pvl_graph.geojson"
+    graph_filepath: "/home/ubuntu/cda_ws/src/cda1tenth-bringup/graphs/pvl_graph.geojson"
     boundary_radius_to_achieve_node: 1.0
     radius_to_achieve_node: 2.0
     edge_cost_functions: ["DistanceScorer", "CostmapScorer"]

--- a/params/params.yaml
+++ b/params/params.yaml
@@ -44,11 +44,11 @@ bt_navigator:
     robot_base_frame: base_link
     odom_topic: odom
     navigators: ["navigate_to_pose"]
-    default_nav_to_pose_bt_xml: "/home/ubuntu/c1t_ws/src/c1t_bringup/behavior_trees/navigate_through_route_to_pose.xml"
+    default_nav_to_pose_bt_xml: "/home/ubuntu/cda_ws/src/cda1tenth_bringup/behavior_trees/navigate_through_route_to_pose.xml"
     navigate_to_pose:
       plugin: "nav2_bt_navigator/NavigateToPoseNavigator"
     plugin_lib_names:
-      - carma_nav2_compute_route_action_bt_node
+      - nav2_route_server_compute_route_action_bt_node
       - nav2_compute_path_to_pose_action_bt_node
       - nav2_compute_path_through_poses_action_bt_node
       - nav2_smooth_path_action_bt_node
@@ -214,7 +214,7 @@ waypoint_follower:
 
 route_server:
   ros__parameters:
-    graph_filepath: "/home/ubuntu/c1t_ws/src/c1t_bringup/graphs/pvl_graph.geojson"
+    graph_filepath: "/home/ubuntu/cda_ws/src/cda1tenth_bringup/graphs/pvl_graph.geojson"
     boundary_radius_to_achieve_node: 1.0
     radius_to_achieve_node: 2.0
     edge_cost_functions: ["DistanceScorer", "CostmapScorer"]

--- a/params/red_truck_params.yaml
+++ b/params/red_truck_params.yaml
@@ -44,11 +44,11 @@ bt_navigator:
     robot_base_frame: base_link
     odom_topic: odom
     navigators: ["navigate_to_pose"]
-    default_nav_to_pose_bt_xml: "/home/ubuntu/c1t_ws/src/c1t_bringup/behavior_trees/navigate_through_route_to_pose.xml"
+    default_nav_to_pose_bt_xml: "/home/ubuntu/cda_ws/src/cda1tenth_bringup/behavior_trees/navigate_through_route_to_pose.xml"
     navigate_to_pose:
       plugin: "nav2_bt_navigator/NavigateToPoseNavigator"
     plugin_lib_names:
-      - carma_nav2_compute_route_action_bt_node
+      - nav2_route_server_compute_route_action_bt_node
       - nav2_compute_path_to_pose_action_bt_node
       - nav2_compute_path_through_poses_action_bt_node
       - nav2_smooth_path_action_bt_node
@@ -193,7 +193,7 @@ velocity_smoother:
 
 route_server:
   ros__parameters:
-    graph_filepath: "/home/ubuntu/c1t_ws/src/c1t_bringup/graphs/garage_center_line.geojson"
+    graph_filepath: "/home/ubuntu/cda_ws/src/cda1tenth_bringup/graphs/garage_center_line.geojson"
     boundary_radius_to_achieve_node: 1.0
     radius_to_achieve_node: 2.0
     edge_cost_functions: ["DistanceScorer", "CostmapScorer"]
@@ -263,5 +263,5 @@ vesc_driver_node:
 
 port_drayage_demo:
   ros__parameters:
-    cmv_id: "C1T-1" # Vehicle's ID for Port Drayage use case (ID must match on infrastructure side)
+    cmv_id: "RED-TRUCK" # Vehicle's ID for Port Drayage use case (ID must match on infrastructure side)
     message_processing_delay: 0 # Time to wait after receiving a new command before driving

--- a/params/red_truck_params.yaml
+++ b/params/red_truck_params.yaml
@@ -44,7 +44,7 @@ bt_navigator:
     robot_base_frame: base_link
     odom_topic: odom
     navigators: ["navigate_to_pose"]
-    default_nav_to_pose_bt_xml: "/home/ubuntu/cda_ws/src/cda1tenth_bringup/behavior_trees/navigate_through_route_to_pose.xml"
+    default_nav_to_pose_bt_xml: "/home/ubuntu/cda_ws/src/cda1tenth-bringup/behavior_trees/navigate_through_route_to_pose.xml"
     navigate_to_pose:
       plugin: "nav2_bt_navigator/NavigateToPoseNavigator"
     plugin_lib_names:
@@ -193,7 +193,7 @@ velocity_smoother:
 
 route_server:
   ros__parameters:
-    graph_filepath: "/home/ubuntu/cda_ws/src/cda1tenth_bringup/graphs/garage_center_line.geojson"
+    graph_filepath: "/home/ubuntu/cda_ws/src/cda1tenth-bringup/graphs/garage_center_line.geojson"
     boundary_radius_to_achieve_node: 1.0
     radius_to_achieve_node: 2.0
     edge_cost_functions: ["DistanceScorer", "CostmapScorer"]

--- a/params/turtlebot_params.yaml
+++ b/params/turtlebot_params.yaml
@@ -54,11 +54,11 @@ bt_navigator:
     robot_base_frame: base_link
     odom_topic: odom
     navigators: ["navigate_to_pose"]
-    default_nav_to_pose_bt_xml: "/home/$USER/c1t_ws/src/c1t_bringup/behavior_trees/navigate_through_route_to_pose.xml"
+    default_nav_to_pose_bt_xml: "/home/$USER/cda_ws/src/cda1tenth_bringup/behavior_trees/navigate_through_route_to_pose.xml"
     navigate_to_pose:
       plugin: "nav2_bt_navigator/NavigateToPoseNavigator"
     plugin_lib_names:
-    - carma_nav2_compute_route_action_bt_node
+    - nav2_route_server_compute_route_action_bt_node
     - nav2_compute_path_to_pose_action_bt_node
     - nav2_compute_path_through_poses_action_bt_node
     - nav2_follow_path_action_bt_node
@@ -288,7 +288,7 @@ global_costmap:
 map_server:
   ros__parameters:
     use_sim_time: False
-    yaml_filename: "/home/$USER/c1t_ws/src/c1t_bringup/maps/turtlebot_sim.yaml"
+    yaml_filename: "/home/$USER/cda_ws/src/cda1tenth_bringup/maps/turtlebot_sim.yaml"
 
 map_saver:
   ros__parameters:
@@ -350,7 +350,7 @@ waypoint_follower:
 
 route_server:
   ros__parameters:
-    graph_filepath: "/home/$USER/c1t_ws/src/c1t_bringup/graphs/turtlebot_outer_loop.geojson"
+    graph_filepath: "/home/$USER/cda_ws/src/cda1tenth_bringup/graphs/turtlebot_outer_loop.geojson"
     boundary_radius_to_achieve_node: 1.0
     radius_to_achieve_node: 2.0
     edge_cost_functions: ["DistanceScorer", "CostmapScorer"]

--- a/params/turtlebot_params.yaml
+++ b/params/turtlebot_params.yaml
@@ -54,7 +54,7 @@ bt_navigator:
     robot_base_frame: base_link
     odom_topic: odom
     navigators: ["navigate_to_pose"]
-    default_nav_to_pose_bt_xml: "/home/$USER/cda_ws/src/cda1tenth_bringup/behavior_trees/navigate_through_route_to_pose.xml"
+    default_nav_to_pose_bt_xml: "/home/$USER/cda_ws/src/cda1tenth-bringup/behavior_trees/navigate_through_route_to_pose.xml"
     navigate_to_pose:
       plugin: "nav2_bt_navigator/NavigateToPoseNavigator"
     plugin_lib_names:
@@ -288,7 +288,7 @@ global_costmap:
 map_server:
   ros__parameters:
     use_sim_time: False
-    yaml_filename: "/home/$USER/cda_ws/src/cda1tenth_bringup/maps/turtlebot_sim.yaml"
+    yaml_filename: "/home/$USER/cda_ws/src/cda1tenth-bringup/maps/turtlebot_sim.yaml"
 
 map_saver:
   ros__parameters:
@@ -350,7 +350,7 @@ waypoint_follower:
 
 route_server:
   ros__parameters:
-    graph_filepath: "/home/$USER/cda_ws/src/cda1tenth_bringup/graphs/turtlebot_outer_loop.geojson"
+    graph_filepath: "/home/$USER/cda_ws/src/cda1tenth-bringup/graphs/turtlebot_outer_loop.geojson"
     boundary_radius_to_achieve_node: 1.0
     radius_to_achieve_node: 2.0
     edge_cost_functions: ["DistanceScorer", "CostmapScorer"]


### PR DESCRIPTION
# PR Details
## Description

This PR replaces references to CARMA1tenth (C1T) with CDA1tenth.

## Related GitHub Issue

NA

## Related Jira Key

[CF-947](https://usdot-carma.atlassian.net/browse/CF-947)

## Motivation and Context

CDA1tenth has been chosen as the name to encapsulate the Port Drayage proof-of-concept project and the follow-on workforce development project. So, we are replacing all references to the former CARMA1tenth (C1T) project to CDA1tenth.

## How Has This Been Tested?

Tested the port drayage demo on the vehicle with all renaming changes pulled to vehicle, infrastructure, and Raspberry Pis.

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[CF-947]: https://usdot-carma.atlassian.net/browse/CF-947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ