### PR TITLE
updated behavior tree to enable dynamic rerouting

### DIFF
--- a/behavior_trees/navigate_through_route_to_pose.xml
+++ b/behavior_trees/navigate_through_route_to_pose.xml
@@ -2,7 +2,7 @@
   <BehaviorTree ID="MainTree">
     <PipelineSequence name="NavigateThroughRouteToPose">
       <RateController hz="1.0">
-        <ComputeRoute goal="{updated_goal}" path="{path}" error_code_id="{compute_route_error_code}"/>
+        <ComputeRoute goal="{goal}" path="{path}" error_code_id="{compute_route_error_code}"/>
       </RateController>
       <FollowPath path="{path}" controller_id="FollowPath" error_code_id="{follow_path_error_code}"/>
     </PipelineSequence>

--- a/behavior_trees/navigate_through_route_to_pose.xml
+++ b/behavior_trees/navigate_through_route_to_pose.xml
@@ -1,7 +1,9 @@
 <root main_tree_to_execute="MainTree">
   <BehaviorTree ID="MainTree">
     <PipelineSequence name="NavigateThroughRouteToPose">
-      <ComputeRoute goal="{goal}" path="{path}" error_code_id="{compute_route_error_code}"/>
+      <RateController hz="1.0">
+        <ComputeRoute goal="{updated_goal}" path="{path}" error_code_id="{compute_route_error_code}"/>
+      </RateController>
       <FollowPath path="{path}" controller_id="FollowPath" error_code_id="{follow_path_error_code}"/>
     </PipelineSequence>
   </BehaviorTree>


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

This PR adds behavior tree edits that enable dynamic rerouting. This is achieved by configuring the planner to run at 1 Hz instead of once every time a goal is received.

Related PR: https://github.com/usdot-fhwa-stol/navigation2-extensions/pull/20

## Related GitHub Issue

NA

## Related Jira Key

[CF-965](https://usdot-carma.atlassian.net/browse/CF-965)

## Motivation and Context

In the event a vehicle receives a new goal while it is actively executing another, we want the vehicle to abandon its current goal and instead take on the new goal.

## How Has This Been Tested?

Tested in the turtlebot simulator and on the red truck in the garage environment. Ensured that the vehicle correctly abandons its current goal in favor of a new goal and broadcasts the correct ack when the new goal is finished.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[CF-965]: https://usdot-carma.atlassian.net/browse/CF-965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ