### PR TITLE
CF 970 TRB Followup

### DIFF
--- a/behavior_trees/navigate_through_route_to_pose.xml
+++ b/behavior_trees/navigate_through_route_to_pose.xml
@@ -1,10 +1,12 @@
 <root main_tree_to_execute="MainTree">
   <BehaviorTree ID="MainTree">
+  <RetryUntilSuccessful name="RetryUntilSuccess" num_attempts="30000">
     <PipelineSequence name="NavigateThroughRouteToPose">
       <RateController hz="1.0">
         <ComputeRoute goal="{goal}" path="{path}" error_code_id="{compute_route_error_code}"/>
       </RateController>
       <FollowPath path="{path}" controller_id="FollowPath" error_code_id="{follow_path_error_code}"/>
     </PipelineSequence>
+  </RetryUntilSuccessful>
   </BehaviorTree>
 </root>

--- a/behavior_trees/navigate_through_route_to_pose.xml
+++ b/behavior_trees/navigate_through_route_to_pose.xml
@@ -1,6 +1,6 @@
 <root main_tree_to_execute="MainTree">
   <BehaviorTree ID="MainTree">
-  <RetryUntilSuccessful name="RetryUntilSuccess" num_attempts="30000">
+  <RetryUntilSuccessful name="RetryUntilSuccess" num_attempts="50">
     <PipelineSequence name="NavigateThroughRouteToPose">
       <RateController hz="1.0">
         <ComputeRoute goal="{goal}" path="{path}" error_code_id="{compute_route_error_code}"/>


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

This PR adds a retry mechanism to the Nav2 behavior tree used for the port drayage demo so that Nav2 will continuously try to navigate to the requested goal in the event that it initially fails due to high network latency.
## Related GitHub Issue
NA

## Related Jira Key

[CF-970](https://usdot-carma.atlassian.net/browse/CF-970)

## Motivation and Context

This change is needed to make the port drayage demo more robust to high latency environments, such as what was experience at TRB.

## How Has This Been Tested?

Tested on the truck at TRB and confirmed that Nav2 would continue to retry to execute a goal instead of aborting the goal when latency was high.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[CF-970]: https://usdot-carma.atlassian.net/browse/CF-970?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ